### PR TITLE
Update CI to use Node.js LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: required
 
 node_js:
-  - "9"
+  - '10'
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-sudo: required
+
+dist: xenial
 
 node_js:
   - '10'
@@ -13,10 +14,6 @@ env:
     - ARTIFACTS_DIR=artifacts
     - ARTIFACT_NAME=reputation-contracts
     - ARTIFACT_EXT=zip
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y jq
 
 install:
   - npm install


### PR DESCRIPTION
Should use Node.js LTS releases.
Also, switching to Xenial distro lets skip `jq` install (as its preinstalled) which should speed-up Travis job